### PR TITLE
Disable OpenMP in OpenFAST develop branch 

### DIFF
--- a/repos/exawind/packages/openfast/package.py
+++ b/repos/exawind/packages/openfast/package.py
@@ -10,7 +10,7 @@ from spack.pkg.builtin.openfast import Openfast as bOpenfast
 class Openfast(bOpenfast):
     patch("hub_seg_fault.patch", when="@2.7:3.2")
     patch("segfault_message.patch", when="%clang@12.0.1 build_type=RelWithDebInfo")
-    patch("openmp.patch", when="@develop%apple-clang")
+    patch("openmp.patch", when="@develop")
     version("fsi", git="https://github.com/gantech/openfast.git", branch="f/br_fsi_2")
 
     variant("rosco", default=False,


### PR DESCRIPTION
This fixes a segfault in the Intel OneAPI compiler.