### PR TITLE
Use latest tagged hypre

### DIFF
--- a/configs/base/packages.yaml
+++ b/configs/base/packages.yaml
@@ -20,7 +20,7 @@ packages:
   openfast:
     version: [develop]
   hypre:
-    version: [2.30.0]
+    version: [2.31.0]
     variants: ~fortran
   trilinos:
     variants: ~adelus~adios2~amesos~amesos2~anasazi~asan+aztec~basker~belos~boost~chaco~complex~dtk~epetra~epetraext~epetraextbtf~epetraextexperimental~epetraextgraphreorderings~float~fortran~hypre~ifpack~ifpack2~intrepid~intrepid2~ipo~isorropia~mesquite~minitensor~ml~muelu~mumps~nox~openmp~panzer~phalanx~piro~python~rol~rythmos~sacado~scorec~shards~shylu~stk_simd~stk_unit_tests~stokhos~stratimikos~strumpack~suite-sparse~superlu~superlu-dist~teko~tempus~test~thyra~trilinoscouplings~x11~zoltan2


### PR DESCRIPTION
I think we might as well use the latest release since 2.30 didn't actually solve my segfaults.