### PR TITLE
Use latest compiler and MPI on Sunspot

### DIFF
--- a/configs/sunspot/compilers.yaml
+++ b/configs/sunspot/compilers.yaml
@@ -1,18 +1,16 @@
 compilers:
   - compiler:
-      spec: oneapi@2023.2
+      spec: oneapi@2024.1
       paths:
-        cc: /soft/compilers/oneapi/2023.10.15.001/oneapi/compiler/2023.2.0/linux/bin/icx
-        cxx: /soft/compilers/oneapi/2023.10.15.001/oneapi/compiler/2023.2.0/linux/bin/icpx
-        f77: /soft/compilers/oneapi/2023.10.15.001/oneapi/compiler/2023.2.0/linux/bin/ifx
-        fc: /soft/compilers/oneapi/2023.10.15.001/oneapi/compiler/2023.2.0/linux/bin/ifx
+        cc: /opt/aurora/23.275.2/CNDA/oneapi/compiler/eng-20231130/bin/icx
+        cxx: /opt/aurora/23.275.2/CNDA/oneapi/compiler/eng-20231130/bin/icpx
+        f77: /opt/aurora/23.275.2/CNDA/oneapi/compiler/eng-20231130/bin/ifx
+        fc: /opt/aurora/23.275.2/CNDA/oneapi/compiler/eng-20231130/bin/ifx
       flags: {}
       operating_system: sles15
       target: x86_64
       modules:
-        - oneapi/release/2023.10.15.001
-        - intel_compute_runtime/release/agama-devel-647
+        - oneapi/eng-compiler/2023.12.15.002
+        - intel_compute_runtime/release/agama-devel-736.25
       environment: {}
-        #  set:
-        #  DPLROOT: /lus/gecko/projects/CSC249ADSE13_CNDA/$user/exawind/oneDPL
       extra_rpaths: []

--- a/configs/sunspot/packages.yaml
+++ b/configs/sunspot/packages.yaml
@@ -4,13 +4,10 @@ packages:
     buildable: false
     externals:
       - spec: "mpich@52.2"
-        prefix: /soft/restricted/CNDA/updates/mpich/52.2/mpich-ofi-all-icc-default-pmix-gpu-drop52
+        prefix: /opt/aurora/23.275.2/CNDA/mpich/52.2/mpich-ofi-all-icc-default-pmix-gpu-drop52
         modules:
-          - mpich/52.2/icc-all-pmix-gpu 
+          - mpich/icc-all-pmix-gpu/52.2
           - libfabric/1.15.2.0
-  trilinos:
-    require:
-      - any_of: ["@=14.1.0.2023.02.28", "@develop"]
   mpi:
     require: "mpich@52.2"
   blas:
@@ -19,4 +16,4 @@ packages:
     require: "openblas"
   all:
     require:
-      - "%oneapi@2023.2"
+      - "%oneapi@2024.1"


### PR DESCRIPTION
The older trilinos didn't allow this, but the latest trilinos works with the latest Intel OneAPI compilers.