### PR TITLE
Added toss4 configuration for SNL HPC machines

### DIFF
--- a/configs/toss4/compilers.yaml
+++ b/configs/toss4/compilers.yaml
@@ -1,0 +1,66 @@
+compilers:
+- compiler:
+    spec: gcc@=12.1.0
+    paths:
+      cc: /projects/aue/hpc/builds/x86_64/rhel8/ba17d7f2/gcc-12.1.0/install/linux-rhel8-x86_64/gcc-10.3.0/gcc-12.1.0-xpyjv5s/bin/gcc
+      cxx: /projects/aue/hpc/builds/x86_64/rhel8/ba17d7f2/gcc-12.1.0/install/linux-rhel8-x86_64/gcc-10.3.0/gcc-12.1.0-xpyjv5s/bin/g++
+      f77: /projects/aue/hpc/builds/x86_64/rhel8/ba17d7f2/gcc-12.1.0/install/linux-rhel8-x86_64/gcc-10.3.0/gcc-12.1.0-xpyjv5s/bin/gfortran
+      fc: /projects/aue/hpc/builds/x86_64/rhel8/ba17d7f2/gcc-12.1.0/install/linux-rhel8-x86_64/gcc-10.3.0/gcc-12.1.0-xpyjv5s/bin/gfortran
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules: [aue/gcc/12.1.0, aue/binutils/2.41]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: dpcpp@=2023.2.0
+    paths:
+      cc: /projects/aue/hpc/builds/x86_64/rhel8/ba17d7f2/intel-2023.2.0/install/linux-rhel8-x86_64/gcc-10.3.0/intel-oneapi-compilers-2023.2.0-v3dnk52/compiler/2023.2.0/linux/bin/icx
+      cxx: /projects/aue/hpc/builds/x86_64/rhel8/ba17d7f2/intel-2023.2.0/install/linux-rhel8-x86_64/gcc-10.3.0/intel-oneapi-compilers-2023.2.0-v3dnk52/compiler/2023.2.0/linux/bin/dpcpp
+      f77: /projects/aue/hpc/builds/x86_64/rhel8/ba17d7f2/intel-2023.2.0/install/linux-rhel8-x86_64/gcc-10.3.0/intel-oneapi-compilers-2023.2.0-v3dnk52/compiler/2023.2.0/linux/bin/ifx
+      fc: /projects/aue/hpc/builds/x86_64/rhel8/ba17d7f2/intel-2023.2.0/install/linux-rhel8-x86_64/gcc-10.3.0/intel-oneapi-compilers-2023.2.0-v3dnk52/compiler/2023.2.0/linux/bin/ifx
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules: [aue/intel-oneapi-compilers/2023.2.0, aue/binutils/2.41]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: intel@=2021.10.0
+    paths:
+      cc: /projects/aue/hpc/builds/x86_64/rhel8/ba17d7f2/intel-2023.2.0/install/linux-rhel8-x86_64/gcc-10.3.0/intel-oneapi-compilers-2023.2.0-v3dnk52/compiler/2023.2.0/linux/bin/intel64/icc
+      cxx: /projects/aue/hpc/builds/x86_64/rhel8/ba17d7f2/intel-2023.2.0/install/linux-rhel8-x86_64/gcc-10.3.0/intel-oneapi-compilers-2023.2.0-v3dnk52/compiler/2023.2.0/linux/bin/intel64/icpc
+      f77: /projects/aue/hpc/builds/x86_64/rhel8/ba17d7f2/intel-2023.2.0/install/linux-rhel8-x86_64/gcc-10.3.0/intel-oneapi-compilers-2023.2.0-v3dnk52/compiler/2023.2.0/linux/bin/intel64/ifort
+      fc: /projects/aue/hpc/builds/x86_64/rhel8/ba17d7f2/intel-2023.2.0/install/linux-rhel8-x86_64/gcc-10.3.0/intel-oneapi-compilers-2023.2.0-v3dnk52/compiler/2023.2.0/linux/bin/intel64/ifort
+    flags: {}
+    operating_system: rhel7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: oneapi@=2023.2.0
+    paths:
+      cc: /projects/aue/hpc/builds/x86_64/rhel8/ba17d7f2/intel-2023.2.0/install/linux-rhel8-x86_64/gcc-10.3.0/intel-oneapi-compilers-2023.2.0-v3dnk52/compiler/2023.2.0/linux/bin/icx
+      cxx: /projects/aue/hpc/builds/x86_64/rhel8/ba17d7f2/intel-2023.2.0/install/linux-rhel8-x86_64/gcc-10.3.0/intel-oneapi-compilers-2023.2.0-v3dnk52/compiler/2023.2.0/linux/bin/icpx
+      f77: /projects/aue/hpc/builds/x86_64/rhel8/ba17d7f2/intel-2023.2.0/install/linux-rhel8-x86_64/gcc-10.3.0/intel-oneapi-compilers-2023.2.0-v3dnk52/compiler/2023.2.0/linux/bin/ifx
+      fc: /projects/aue/hpc/builds/x86_64/rhel8/ba17d7f2/intel-2023.2.0/install/linux-rhel8-x86_64/gcc-10.3.0/intel-oneapi-compilers-2023.2.0-v3dnk52/compiler/2023.2.0/linux/bin/ifx
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules: [aue/intel-oneapi-compilers/2023.2.0, aue/binutils/2.41]
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: clang@=16.0.6
+    paths:
+      cc: /projects/aue/hpc/builds/x86_64/rhel8/ba17d7f2/clang-16.0.6/install/linux-rhel8-x86_64/clang-16.0.6/llvm-16.0.6-dk6jfj6/bin/clang
+      cxx: /projects/aue/hpc/builds/x86_64/rhel8/ba17d7f2/clang-16.0.6/install/linux-rhel8-x86_64/clang-16.0.6/llvm-16.0.6-dk6jfj6/bin/clang++
+      f77: /projects/aue/hpc/builds/x86_64/rhel8/ba17d7f2/gcc-12.1.0/install/linux-rhel8-x86_64/gcc-10.3.0/gcc-12.1.0-xpyjv5s/bin/gfortran
+      fc: /projects/aue/hpc/builds/x86_64/rhel8/ba17d7f2/gcc-12.1.0/install/linux-rhel8-x86_64/gcc-10.3.0/gcc-12.1.0-xpyjv5s/bin/gfortran
+    flags: {}
+    operating_system: rhel8
+    target: x86_64
+    modules: [aue/clang/16.0.6, aue/binutils/2.41]
+    environment: {}
+    extra_rpaths: []

--- a/configs/toss4/packages.yaml
+++ b/configs/toss4/packages.yaml
@@ -1,0 +1,44 @@
+packages:
+  all:
+    permissions:
+      read: group
+      group: wg-sierra-users
+    variants: +mpi build_type=Release cuda_arch=70
+    target: [x86_64]
+    providers:
+      mpi: [openmpi]
+  python:
+    externals:
+    - spec: python@3.11.6+bz2+crypt+ctypes+dbm+lzma+nis+pyexpat+pythoncmd+readline+sqlite3+ssl~tkinter+uuid+zlib
+      prefix: /projects/aue/hpc/builds/x86_64/rhel8/f6a36cb8/tooling-sprint-24.02/install/linux-rhel8-x86_64/gcc-10.3.0/python-3.11.6-qvlrkva
+  cuda:
+    externals:
+    - spec: cuda@11.2.152
+      prefix: /projects/aue/cee/builds/x86_64/rhel7/ba17d7f2/cuda-11.2.2/install/linux-rhel7-x86_64/gcc-12.1.0/cuda-11.2.2-y3xhorr
+  ninja:
+    externals:
+    - spec: ninja@1.11.1
+      prefix: /projects/aue/hpc/builds/x86_64/rhel8/ba17d7f2/tooling/install/linux-rhel8-x86_64/gcc-10.3.0/ninja-1.11.1-cjf3fb5
+  openmpi:
+    externals:
+    - spec: openmpi@4.1.6%gcc@12.1.0
+      prefix: /projects/aue/hpc/builds/x86_64/rhel8/ba17d7f2/openmpi-4.1.6-gcc-12.1.0/install/linux-rhel8-x86_64/gcc-12.1.0/openmpi-4.1.6-7vf2ucr
+    buildable: false
+  cmake:
+    externals:
+    - spec: cmake@3.27.7
+      prefix: /projects/aue/hpc/builds/x86_64/rhel8/f6a36cb8/tooling-sprint-24.02/install/linux-rhel8-x86_64/gcc-10.3.0/cmake-3.27.7-f3bfcza
+    buildable: false
+  curl:
+    externals:
+    - spec: curl@7.29.0+ldap
+      prefix: /usr
+  openssl:
+    externals:
+    - spec: openssl@1.0.2k-fips
+      prefix: /usr
+  boost:
+    externals:
+    - spec: boost@1.83.0
+      prefix: /projects/aue/hpc/builds/x86_64/rhel8/c8f7ebb0/tpls-gcc-12.1.0-openmpi-4.1.6/install/linux-rhel8-x86_64/gcc-12.1.0/boost-1.83.0-em7p3wm
+    buildable: false

--- a/configs/toss4/rhel8_setup.yaml
+++ b/configs/toss4/rhel8_setup.yaml
@@ -1,0 +1,19 @@
+externals:
+  - curl
+  - openssl
+compilers:
+  - aue/gcc/12.1.0
+  - aue/intel-oneapi-compilers/2023.2.0
+  - aue/clang/16.0.6
+modules:
+  - module: aue/cmake/3.27.7
+    packages: [cmake]
+  - module: aue/openmpi/4.1.6-gcc-12.1.0
+    packages: [openmpi]
+  - module: aue/ninja/1.11.1
+    packages: [ninja]
+  - module: aue/cuda/11.2.2-gcc-12.1.0
+    packages: [cuda]
+  - module: aue/python/3.11.6
+    packages: [python]
+


### PR DESCRIPTION
Updated compilers for the RHEL8 TOSS4 machines at Sandia.  Note that only the gcc 12.1 compilers have been tested, but all compiler paths have been updated.