### PR TITLE
Updates to kestrel configs

### DIFF
--- a/configs/kestrel/compilers.yaml
+++ b/configs/kestrel/compilers.yaml
@@ -12,16 +12,13 @@ compilers:
       modules: []
       extra_rpaths: []
       environment: {}
-  - compiler:
-      spec: gcc@=8.5.0
-      paths:
-        cc: /usr/bin/gcc
-        cxx: /usr/bin/g++
-        f77: /usr/bin/gfortran
-        fc: /usr/bin/gfortran
-      flags: {}
-      operating_system: rhel8
-      target: x86_64
-      modules: []
-      environment: {}
-      extra_rpaths: []
+   - compiler:
+       spec: gcc@12.2.0
+       paths:
+         cc: /opt/cray/pe/gcc/12.2.0/bin/gcc
+         cxx: /opt/cray/pe/gcc/12.2.0/bin/g++
+         f77: /opt/cray/pe/gcc/12.2.0/bin/gfortran
+         fc: /opt/cray/pe/gcc/12.2.0/bin/gfortran
+       flags: {}
+       operating_system: rhel8
+       target: x86_64

--- a/configs/kestrel/compilers.yaml
+++ b/configs/kestrel/compilers.yaml
@@ -13,12 +13,15 @@ compilers:
       extra_rpaths: []
       environment: {}
    - compiler:
-       spec: gcc@12.2.0
-       paths:
-         cc: /opt/cray/pe/gcc/12.2.0/bin/gcc
-         cxx: /opt/cray/pe/gcc/12.2.0/bin/g++
-         f77: /opt/cray/pe/gcc/12.2.0/bin/gfortran
-         fc: /opt/cray/pe/gcc/12.2.0/bin/gfortran
-       flags: {}
-       operating_system: rhel8
-       target: x86_64
+      spec: gcc@12.2.0
+      paths:
+        cc: /opt/cray/pe/gcc/12.2.0/bin/gcc
+        cxx: /opt/cray/pe/gcc/12.2.0/bin/g++
+        f77: /opt/cray/pe/gcc/12.2.0/bin/gfortran
+        fc: /opt/cray/pe/gcc/12.2.0/bin/gfortran
+      flags: {}
+      operating_system: rhel8
+      target: x86_64
+      modules: []
+      extra_rpaths: []
+      environment: {}

--- a/configs/kestrel/compilers.yaml
+++ b/configs/kestrel/compilers.yaml
@@ -15,7 +15,7 @@ compilers:
   - compiler:
       spec: gcc@12.2.0
       paths:
-       cc: /opt/cray/pe/gcc/12.2.0/bin/gcc
+        cc: /opt/cray/pe/gcc/12.2.0/bin/gcc
         cxx: /opt/cray/pe/gcc/12.2.0/bin/g++
         f77: /opt/cray/pe/gcc/12.2.0/bin/gfortran
         fc: /opt/cray/pe/gcc/12.2.0/bin/gfortran

--- a/configs/kestrel/compilers.yaml
+++ b/configs/kestrel/compilers.yaml
@@ -12,10 +12,10 @@ compilers:
       modules: []
       extra_rpaths: []
       environment: {}
-   - compiler:
+  - compiler:
       spec: gcc@12.2.0
       paths:
-        cc: /opt/cray/pe/gcc/12.2.0/bin/gcc
+       cc: /opt/cray/pe/gcc/12.2.0/bin/gcc
         cxx: /opt/cray/pe/gcc/12.2.0/bin/g++
         f77: /opt/cray/pe/gcc/12.2.0/bin/gfortran
         fc: /opt/cray/pe/gcc/12.2.0/bin/gfortran

--- a/configs/kestrel/compilers.yaml
+++ b/configs/kestrel/compilers.yaml
@@ -12,3 +12,16 @@ compilers:
       modules: []
       extra_rpaths: []
       environment: {}
+  - compiler:
+      spec: gcc@=8.5.0
+      paths:
+        cc: /usr/bin/gcc
+        cxx: /usr/bin/g++
+        f77: /usr/bin/gfortran
+        fc: /usr/bin/gfortran
+      flags: {}
+      operating_system: rhel8
+      target: x86_64
+      modules: []
+      environment: {}
+      extra_rpaths: []

--- a/configs/kestrel/packages.yaml
+++ b/configs/kestrel/packages.yaml
@@ -16,4 +16,6 @@ packages:
   all:
     require:
       # strong preference for oneapi, allow gcc for gcc-runtime
-      - any_of: ["%oneapi@2023.2.0", "@:"]
+      # concretizer should always pick oneapi unless something can't use it
+      # due to ordering of requires
+      - any_of: ["%oneapi@2023.2.0", "@gcc"]

--- a/configs/kestrel/packages.yaml
+++ b/configs/kestrel/packages.yaml
@@ -15,4 +15,5 @@ packages:
     require: "openblas"
   all:
     require:
-      - "%oneapi@2023.2.0"
+      # strong preference for oneapi, allow gcc for gcc-runtime
+      - any_of: ["%oneapi@2023.2.0", "@:"]

--- a/configs/kestrel/packages.yaml
+++ b/configs/kestrel/packages.yaml
@@ -14,8 +14,5 @@ packages:
   lapack:
     require: "openblas"
   all:
-    require:
-      # strong preference for oneapi, allow gcc for gcc-runtime
-      # concretizer should always pick oneapi unless something can't use it
-      # due to ordering of requires
-      - any_of: ["%oneapi@2023.2.0", "@gcc"]
+    prefer:
+      - "%oneapi@2023.2.0"


### PR DESCRIPTION
Accounts for spack's runtime modeling where oneapi runtime depends on gcc-runtime and gcc-runtime requires gcc