### PR TITLE
Relax openfast versions

### DIFF
--- a/configs/base/packages.yaml
+++ b/configs/base/packages.yaml
@@ -17,8 +17,6 @@ packages:
     variants: ~fortran
   tioga:
     version: [develop]
-  openfast:
-    version: [develop]
   hypre:
     version: [2.31.0]
     variants: ~fortran


### PR DESCRIPTION
We have migrated enough to spack to allow it to choose preferred versions of openfast.