### PR TITLE
Remove concretizer option as obsolete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ __pycache__
 Configuring
 .tmp/
 *.swp
+*.py-e

--- a/configs/aurora/template.yaml
+++ b/configs/aurora/template.yaml
@@ -1,7 +1,4 @@
 spack:
-  concretizer:
-    unify: false
-    reuse: false
   view: false
   specs:
     - 'exawind+fsi+ninja+hypre+amr_wind_gpu~nalu_wind_gpu+sycl'

--- a/configs/azure/template.yaml
+++ b/configs/azure/template.yaml
@@ -1,7 +1,4 @@
 spack:
-  concretizer:
-    unify: false
-    reuse: false
   view: false
   config:
     install_tree:

--- a/configs/base/concretizer.yaml
+++ b/configs/base/concretizer.yaml
@@ -1,3 +1,0 @@
-concretizer:
-  unify: false
-  reuse: false

--- a/configs/base/template.yaml
+++ b/configs/base/template.yaml
@@ -1,7 +1,4 @@
 spack:
-  concretizer:
-    unify: false
-    reuse: false
   view: false
   specs:
   - exawind

--- a/configs/cee/concretizer.yaml
+++ b/configs/cee/concretizer.yaml
@@ -1,3 +1,0 @@
-concretizer:
-  os_compatible:
-    rhel8: [rhel7]

--- a/configs/cee/template.yaml
+++ b/configs/cee/template.yaml
@@ -1,7 +1,4 @@
 spack:
-  concretizer:
-    unify: false
-    reuse: false
   view: false
   specs:
   - amr-wind@main%gcc+openfast

--- a/configs/cts-1/template.yaml
+++ b/configs/cts-1/template.yaml
@@ -1,7 +1,4 @@
 spack:
-  concretizer:
-    unify: false
-    reuse: false
   view: false
   specs:
   - exawind@master+fsi%oneapi

--- a/configs/darwin/concretizer.yaml
+++ b/configs/darwin/concretizer.yaml
@@ -1,4 +1,0 @@
-concretizer:
-  reuse: dependencies
-  os_compatible:
-    sonoma: [ ventura ]

--- a/configs/eagle/template.yaml
+++ b/configs/eagle/template.yaml
@@ -1,7 +1,4 @@
 spack:
-  concretizer:
-    unify: false
-    reuse: false
   view: false
   specs:
     - 'exawind+ninja+hypre~amr_wind_gpu~nalu_wind_gpu~cuda%intel'

--- a/configs/ellis/template.yaml
+++ b/configs/ellis/template.yaml
@@ -1,7 +1,4 @@
 spack:
-  concretizer:
-    unify: false
-    reuse: false
   view: false
   specs:
   - exawind~amr_wind_gpu~nalu_wind_gpu~cuda %gcc ^nalu-wind+wind-utils

--- a/configs/frontier/template.yaml
+++ b/configs/frontier/template.yaml
@@ -1,7 +1,4 @@
 spack:
-  concretizer:
-    unify: false
-    reuse: false
   view: false
   specs:
     - 'exawind+amr_wind_gpu+nalu_wind_gpu+rocm'

--- a/configs/kestrel/template.yaml
+++ b/configs/kestrel/template.yaml
@@ -1,7 +1,4 @@
 spack:
-  concretizer:
-    unify: false
-    reuse: false 
   view: false
   specs:
     - 'exawind~amr_wind_gpu~nalu_wind_gpu %oneapi'

--- a/configs/perlmutter/template.yaml
+++ b/configs/perlmutter/template.yaml
@@ -1,7 +1,4 @@
 spack:
-  concretizer:
-    unify: false
-    reuse: false 
   view: false
   specs:
     - 'exawind+hypre+amr_wind_gpu+nalu_wind_gpu+cuda cuda_arch=80'

--- a/configs/summit/template.yaml
+++ b/configs/summit/template.yaml
@@ -1,7 +1,4 @@
 spack:
-  concretizer:
-    unify: false
-    reuse: false
   view: false
   specs:
     - 'exawind+amr_wind_gpu+nalu_wind_gpu+cuda'

--- a/configs/sunspot/template.yaml
+++ b/configs/sunspot/template.yaml
@@ -1,7 +1,4 @@
 spack:
-  concretizer:
-    unify: false
-    reuse: false
   view: false
   specs:
     - 'exawind+amr_wind_gpu~nalu_wind_gpu+sycl'

--- a/scripts/admin-system-setup/production_compilers.yaml
+++ b/scripts/admin-system-setup/production_compilers.yaml
@@ -8,8 +8,6 @@ spack:
   - gcc@10.3.0
   - llvm@13+clang targets=x86 +gold ^ninja@kitware
   view: false
-  concretizer:
-    unify: false
   packages:
     all:
       target: [x86_64]

--- a/scripts/admin-system-setup/production_packages.yaml
+++ b/scripts/admin-system-setup/production_packages.yaml
@@ -22,8 +22,6 @@ spack:
   #    projections:
   #      all: '{compiler.name}/{compiler.version}/{name}/{version}/{hash:8}'
   #    link_type: symlink
-  concretizer:
-    unify: false
   packages:
     all:
       target: [x86_64]

--- a/scripts/nrel-modules/production_compilers.yaml
+++ b/scripts/nrel-modules/production_compilers.yaml
@@ -26,9 +26,6 @@ spack:
    - llvm@13.0.1 +omp_debug+omp_tsan+python build_type=Release
    - llvm@12.0.1 +omp_debug+omp_tsan+python build_type=Release
    view: false
-   concretizer:
-     unify: false
-     reuse: false
    packages:
      perl:
        require: "@5.30.3"

--- a/scripts/nrel-modules/production_packages.yaml
+++ b/scripts/nrel-modules/production_packages.yaml
@@ -86,9 +86,6 @@ spack:
    #    projections:
    #      all: '{compiler.name}/{compiler.version}/{name}/{version}/{hash:8}'
    #    link_type: symlink
-   concretizer:
-     unify: false
-     reuse: true
    packages:
      perl:
        require: "@5.30.3"

--- a/start.sh
+++ b/start.sh
@@ -73,10 +73,6 @@ function spack-start() {
       install_spack_manager
     fi
 
-    if [[ -z $(spack config --scope site blame concretizer | grep 'unify:false') ]]; then
-      spack -E config --scope site add "concretizer:unify:false"
-    fi
-
     if [[ -z $(spack repo list | awk '{print $1" "$2}' | grep "exawind $EXAWIND_MANAGER") ]]; then
       spack -E repo add ${EXAWIND_MANAGER}/repos/exawind
     fi


### PR DESCRIPTION
I think we want this? The option is ignored with the version of spack we use. Should I do this for spack-manager as well? 