### PR TITLE
Revert frontier compilers

### DIFF
--- a/configs/frontier/compilers.yaml
+++ b/configs/frontier/compilers.yaml
@@ -2,18 +2,17 @@ compilers:
   - compiler:
       spec: clang@18.0.0
       paths:
-        cc: /opt/rocm-6.2.4/bin/amdclang
-        cxx: /opt/rocm-6.2.4/bin/amdclang++
-        f77: /opt/rocm-6.2.4/bin/amdflang
-        fc: /opt/rocm-6.2.4/bin/amdflang
+        cc: /opt/rocm-6.1.3/bin/amdclang
+        cxx: /opt/rocm-6.1.3/bin/amdclang++
+        f77: /opt/rocm-6.1.3/bin/amdflang
+        fc: /opt/rocm-6.1.3/bin/amdflang
       flags: {}
       operating_system: sles15
       target: any
       modules:
         - PrgEnv-amd/8.5.0
-        - cpe/24.07
-        - amd/6.2.4
-        - rocm/6.2.4
+        - amd/6.1.3
+        - rocm/6.1.3
         - craype-x86-trento
       extra_rpaths: []
       environment: {}

--- a/configs/frontier/packages.yaml
+++ b/configs/frontier/packages.yaml
@@ -12,67 +12,67 @@ packages:
           - cray-pmi/6.1.13
           - xpmem/2.8.4-1.0_7.3__ga37cbd9.shasta
   rocprim:
-    require: "@6.2.4"
+    require: "@6.1.3"
     buildable: false
     externals:
-      - spec: rocprim@6.2.4
-        prefix: /opt/rocm-6.2.4
+      - spec: rocprim@6.1.3
+        prefix: /opt/rocm-6.1.3
         modules:
-          - rocm/6.2.4
+          - rocm/6.1.3
           - craype-accel-amd-gfx90a
   rocrand:
-    require: "@6.2.4"
+    require: "@6.1.3"
     buildable: false
     externals:
-      - spec: rocrand@6.2.4
-        prefix: /opt/rocm-6.2.4
+      - spec: rocrand@6.1.3
+        prefix: /opt/rocm-6.1.3
         modules:
-          - rocm/6.2.4
+          - rocm/6.1.3
           - craype-accel-amd-gfx90a
   rocthrust:
-    require: "@6.2.4"
+    require: "@6.1.3"
     buildable: false
     externals:
-      - spec: rocthrust@6.2.4
-        prefix: /opt/rocm-6.2.4
+      - spec: rocthrust@6.1.3
+        prefix: /opt/rocm-6.1.3
         modules:
-          - rocm/6.2.4
+          - rocm/6.1.3
           - craype-accel-amd-gfx90a
   rocsparse:
-    require: "@6.2.4"
+    require: "@6.1.3"
     buildable: false
     externals:
-      - spec: rocsparse@6.2.4
-        prefix: /opt/rocm-6.2.4
+      - spec: rocsparse@6.1.3
+        prefix: /opt/rocm-6.1.3
         modules:
-          - rocm/6.2.4
+          - rocm/6.1.3
           - craype-accel-amd-gfx90a
   hip:
-    require: "@6.2.4"
+    require: "@6.1.3"
     buildable: false
     externals:
-      - spec: hip@6.2.4
-        prefix: /opt/rocm-6.2.4
+      - spec: hip@6.1.3
+        prefix: /opt/rocm-6.1.3
         modules:
-          - rocm/6.2.4
+          - rocm/6.1.3
           - craype-accel-amd-gfx90a
   hsa-rocr-dev:
-    require: "@6.2.4"
+    require: "@6.1.3"
     buildable: false
     externals:
-      - spec: hsa-rocr-dev@6.2.4
-        prefix: /opt/rocm-6.2.4
+      - spec: hsa-rocr-dev@6.1.3
+        prefix: /opt/rocm-6.1.3
         modules:
-          - rocm/6.2.4
+          - rocm/6.1.3
           - craype-accel-amd-gfx90a
   llvm-amdgpu:
-    require: "@6.2.4"
+    require: "@6.1.3"
     buildable: false
     externals:
-      - spec: llvm-amdgpu@6.2.4
-        prefix: /opt/rocm-6.2.4/llvm
+      - spec: llvm-amdgpu@6.1.3
+        prefix: /opt/rocm-6.1.3/llvm
         modules:
-          - rocm/6.2.4
+          - rocm/6.1.3
           - craype-accel-amd-gfx90a
   python:
     require: "~ssl"


### PR DESCRIPTION
I had to go back to amd/rocm 6.1.3 on Frontier to avoid a `libamdhip64.so.5: cannot open`. I reported this to OLCF and they said "This issue has been identified as a reported bug with rocm/6.2.4". One of the suggestions was to use 6.1.3 and that seemed to fix the issue. The other suggestion was to use `cpe/24.07` with `rocm/6.2.4` but that would use that cray compilers and we seem to prefer using the `amd` compilers. 

@tasmith4 I am not sure what ramifications this has for you.