### PR TITLE
Fix start script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -81,7 +81,7 @@ function spack-start() {
     export PATH=${PATH}:${EXAWIND_MANAGER}/scripts
     export PYTHONPATH=${PYTHONPATH}:${EXAWIND_MANAGER}:${EXAWIND_MANAGER}/repos:${EXAWIND_MANAGER}/spack/var/spack/repos:${EXAWIND_MANAGER}/spack/lib/spack
 
-    if [[ -z $(spack repo list | awk '{print $1" "$2}' | grep "exawind $EXAWIND_MANAGER") ]]; then
+    if [[ -z $(spack repo list | awk '{print $2" "$4}' | grep "exawind $EXAWIND_MANAGER") ]]; then
       spack -E repo add ${EXAWIND_MANAGER}/repos/spack_repo/exawind
     fi
 


### PR DESCRIPTION
Need this fix because `spack repo list` output changed. 

Old output:
```
❯ spack repo list
==> 2 package repositories.
exawind    /lustre/orion/cfd162/proj-shared/marchdf/exawind/exawind-manager/repos/exawind
builtin    /lustre/orion/cfd162/proj-shared/marchdf/exawind/exawind-manager/spack/var/spack/repos/builtin
```

New:
```
❯ spack repo list
[+] exawind    v2.0    /mnt/vdb/home/mhenryde/exawind/exawind-manager/repos/spack_repo/exawind
 -  builtin            https://github.com/spack/spack-packages.git
```

Without this PR I would get:
```
==> Error: A repository with the name 'exawind' already exists.
```