### PR TITLE
Fix git call command in start script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -35,7 +35,11 @@ function spack-start() {
 
   function install_spack_manager(){
     export SPACK_ROOT=${EXAWIND_MANAGER}/spack
+    ORIGINAL_DIR=$(pwd)
+    cd "$EXAWIND_MANAGER"
     git submodule update ${SPACK_ROOT}/../spack-manager
+    cd "$ORIGINAL_DIR"
+    unset ORIGINAL_DIR
     spack -E config --scope site add "config:extensions:[${EXAWIND_MANAGER}/spack-manager]"
     spack -E manager add ${EXAWIND_MANAGER}
   }


### PR DESCRIPTION
It `spack-start` is called from any directory other than the exawind-manager directory, then the `git` command to add the spack-manager submod fails. I was seeing: `fatal: not a git repository (or any parent up to mount point /mnt)` but I could imagine other errors. This `cd`s to the right repo and goes back to where it was to avoid any other side effects.